### PR TITLE
feat: enhance command handling in recipe parser with conditional error management

### DIFF
--- a/test-data/recipes/test-if-script/recipe.yaml
+++ b/test-data/recipes/test-if-script/recipe.yaml
@@ -1,0 +1,14 @@
+package:
+  name: test-if-script
+  version: 0.1.0
+
+tests:
+  - requirements:
+      run:
+        - bzip2
+    script:
+      - if: unix
+        then: 
+          - test -f ${PREFIX}/fonts/Inconsolata-Regular.ttf
+          - test -f ${PREFIX}/fonts/Inconsolata-Bold.ttf
+ 


### PR DESCRIPTION
fixes #960

I think mapping the if conditions and going with a special case was the correct answer here, I also added an e2e test to make sure it worked, on windows it will not render the script if the if condition is for Unix, so the test doesn’t look for it